### PR TITLE
[sc21964] Remove upper base bound

### DIFF
--- a/monad-trace.cabal
+++ b/monad-trace.cabal
@@ -28,7 +28,7 @@ library
                       UndecidableInstances
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.8 && <4.13,
+  build-depends:       base >=4.8,
                        bytestring,
                        data-default >= 0.5,
                        exceptions >= 0.8,


### PR DESCRIPTION
Upper base bounds can be useful with Cabal and its solver.

But base is unlikely to change the things we use here, so lets
optimistically claim we work with all future base versions.

This fixes GHC 9 compatibility.