### PR TITLE
Import MonadPlus directly, do not depend on mtl export

### DIFF
--- a/src/Control/Monad/Trace.hs
+++ b/src/Control/Monad/Trace.hs
@@ -19,6 +19,7 @@ module Control.Monad.Trace
   ) where
 
 import            Control.Applicative
+import            Control.Monad (MonadPlus)
 import            Control.Monad.Base
 import            Control.Monad.Catch
 import            Control.Monad.Except


### PR DESCRIPTION
mtl-2.3 removed some reexports. Even though mtl-2.3 has problems and was
deprecated, I believe the removal of the MonadPlus re-export was on purpose, so
we may as well use this directly from base.

Tested on mtl-2.2.2 and mtl-2.3 on both GHC 8.6.5 and 9.2.2:

```
% cabal build --constraint='mtl>=2.3' -w ghc-8.6.5
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - monad-trace-0.1.0.0 (lib) (first run)
Preprocessing library for monad-trace-0.1.0.0..
Building library for monad-trace-0.1.0.0..
[1 of 1] Compiling Control.Monad.Trace ( src/Control/Monad/Trace.hs, /home/janus/flipstone/monad-trace/dist-newstyle/build/x86_64-linux/ghc-8.6.5/monad-trace-0.1.0.0/build/Control/Monad/Trace.o )
% cabal build --constraint='mtl>=2.3' -w ghc-9.2.2
Resolving dependencies...
Build profile: -w ghc-9.2.2 -O1
In order, the following will be built (use -v for more details):
 - monad-trace-0.1.0.0 (lib) (configuration changed)
Configuring library for monad-trace-0.1.0.0..
Preprocessing library for monad-trace-0.1.0.0..
Building library for monad-trace-0.1.0.0..
[1 of 1] Compiling Control.Monad.Trace ( src/Control/Monad/Trace.hs, /home/janus/flipstone/monad-trace/dist-newstyle/build/x86_64-linux/ghc-9.2.2/monad-trace-0.1.0.0/build/Control/Monad/Trace.o, /home/janus/flipstone/monad-trace/dist-newstyle/build/x86_64-linux/ghc-9.2.2/monad-trace-0.1.0.0/build/Control/Monad/Trace.dyn_o )
% cabal build --constraint='mtl==2.2.2' -w ghc-9.2.2
Resolving dependencies...
Build profile: -w ghc-9.2.2 -O1
In order, the following will be built (use -v for more details):
 - monad-trace-0.1.0.0 (lib) (configuration changed)
Configuring library for monad-trace-0.1.0.0..
Preprocessing library for monad-trace-0.1.0.0..
Building library for monad-trace-0.1.0.0..
[1 of 1] Compiling Control.Monad.Trace ( src/Control/Monad/Trace.hs, /home/janus/flipstone/monad-trace/dist-newstyle/build/x86_64-linux/ghc-9.2.2/monad-trace-0.1.0.0/build/Control/Monad/Trace.o, /home/janus/flipstone/monad-trace/dist-newstyle/build/x86_64-linux/ghc-9.2.2/monad-trace-0.1.0.0/build/Control/Monad/Trace.dyn_o ) [Control.Monad.Trans changed]
% cabal build --constraint='mtl==2.2.2' -w ghc-8.6.5
Resolving dependencies...
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - exceptions-0.10.5 (lib) (requires build)
 - monad-trace-0.1.0.0 (lib) (configuration changed)
Starting     exceptions-0.10.5 (lib)
Building     exceptions-0.10.5 (lib)
Installing   exceptions-0.10.5 (lib)
Completed    exceptions-0.10.5 (lib)
Configuring library for monad-trace-0.1.0.0..
Preprocessing library for monad-trace-0.1.0.0..
Building library for monad-trace-0.1.0.0..
[1 of 1] Compiling Control.Monad.Trace ( src/Control/Monad/Trace.hs, /home/janus/flipstone/monad-trace/dist-newstyle/build/x86_64-linux/ghc-8.6.5/monad-trace-0.1.0.0/build/Control/Monad/Trace.o ) [Control.Monad.Trans changed]
```
